### PR TITLE
Better error handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -437,6 +437,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "thiserror",
 ]
 
 [[package]]

--- a/dinstaller-cli/Cargo.toml
+++ b/dinstaller-cli/Cargo.toml
@@ -13,3 +13,4 @@ serde_json = "1.0.91"
 serde_yaml = "0.9.17"
 indicatif= "0.17.3"
 async-std = { version ="1.12.0", features = ["attributes"] }
+thiserror = "1.0.39"

--- a/dinstaller-cli/src/error.rs
+++ b/dinstaller-cli/src/error.rs
@@ -1,0 +1,9 @@
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum CliError {
+    #[error("Invalid key name: '{0}'")]
+    InvalidKeyName(String),
+    #[error("Cannot perform the installation as the settings are not valid")]
+    ValidationError,
+}

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -2,19 +2,21 @@ use clap::Parser;
 
 mod commands;
 mod config;
+mod error;
 mod printers;
 mod profile;
 
+use crate::error::CliError;
 use async_std::task::{self, block_on};
 use commands::Commands;
+use config::run as run_config_cmd;
+use dinstaller_lib::error::ServiceError;
 use dinstaller_lib::manager::ManagerClient;
 use indicatif::ProgressBar;
 use printers::Format;
-use std::time::Duration;
-
-use config::run as run_config_cmd;
-use dinstaller_lib::error::ServiceError;
 use profile::run as run_profile_cmd;
+use std::error::Error;
+use std::time::Duration;
 
 #[derive(Parser)]
 #[command(version, about, long_about = None)]
@@ -27,91 +29,88 @@ struct Cli {
     pub format: Option<Format>,
 }
 
-async fn probe(manager: &ManagerClient<'_>) {
-    let probe = task::spawn(async {
-        // use new manager here
-        let another_manager = ManagerClient::new(dinstaller_lib::connection().await.unwrap())
-            .await
-            .unwrap();
-        another_manager.probe().await.unwrap()
-    });
-    block_on(show_progress(&manager));
+async fn probe(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {
+    let another_manager = build_manager().await?;
+    let probe = task::spawn(async move { another_manager.probe().await });
+    show_progress(&manager).await?;
 
-    probe.await
+    Ok(probe.await?)
 }
 
-async fn install(manager: &ManagerClient<'_>) {
-    if !manager.can_install().await.unwrap() {
+async fn install(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {
+    if !manager.can_install().await? {
         // TODO: add some hints what is wrong or add dedicated command for it?
         eprintln!("There are issues with configuration. Cannot install.");
-        return;
+        return Err(Box::new(CliError::ValidationError));
     }
-    let install = task::spawn(async {
-        // use new manager here
-        let another_manager = ManagerClient::new(dinstaller_lib::connection().await.unwrap())
-            .await
-            .unwrap();
-        another_manager.install().await.unwrap()
-    });
-    block_on(show_progress(manager));
+    let another_manager = build_manager().await?;
+    let install = task::spawn(async move { another_manager.install().await });
+    show_progress(&manager).await?;
 
-    install.await
+    Ok(install.await?)
 }
 
-async fn show_progress(client: &ManagerClient<'_>) {
+async fn show_progress(client: &ManagerClient<'_>) -> Result<(), ServiceError> {
     // wait 1 second to give other task chance to start, so progress can display something
     task::sleep(Duration::from_secs(1)).await;
-    let mut progress = client.progress().await.unwrap();
+    let mut progress = client.progress().await?;
     eprintln!("Showing progress with max steps {:?}", progress.max_steps);
     let pb = ProgressBar::new(progress.max_steps.into());
     loop {
         if progress.finished {
             pb.finish();
-            return;
+            return Ok(());
         }
         pb.set_position(progress.current_step.into()); // TODO: display also title somewhere
         std::thread::sleep(std::time::Duration::from_secs(1));
-        progress = client.progress().await.unwrap();
+        progress = client.progress().await?;
     }
 }
 
-async fn wait_for_services(manager: &ManagerClient<'_>) {
-    let services = manager.busy_services().await.unwrap();
+async fn wait_for_services(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {
+    let services = manager.busy_services().await?;
     // TODO: having it optional
     if !services.is_empty() {
         eprintln!("There are busy services {services:?}. Waiting for them.");
-        show_progress(manager).await
+        show_progress(manager).await?
     }
+    Ok(())
 }
 
-async fn build_manager<'a>() -> Result<ManagerClient<'a>, ServiceError> {
+async fn build_manager<'a>() -> Result<ManagerClient<'a>, Box<dyn Error>> {
     let conn = dinstaller_lib::connection().await?;
     Ok(ManagerClient::new(conn).await?)
 }
 
-#[async_std::main]
-async fn main() {
-    let manager = match block_on(build_manager()) {
-        Ok(manager) => manager,
-        Err(error) => {
-            eprintln!("{}", error);
-            return;
-        }
-    };
-
-    // get all attributes to proxy, so later we can rely on signals when dbus service will be blocked
-    block_on(manager.progress()).unwrap().max_steps;
-    block_on(wait_for_services(&manager));
-    let cli = Cli::parse();
+async fn run_command(cli: Cli) -> Result<(), Box<dyn Error>> {
     match cli.command {
-        Commands::Config(subcommand) => block_on(run_config_cmd(subcommand, cli.format)).unwrap(),
-        Commands::Probe => block_on(probe(&manager)),
-        Commands::Profile(subcommand) => {
-            if let Err(error) = run_profile_cmd(subcommand) {
-                eprintln!("{}", error);
-            }
+        Commands::Config(subcommand) => {
+            let manager = build_manager().await?;
+            block_on(wait_for_services(&manager))?;
+            block_on(run_config_cmd(subcommand, cli.format))
         }
-        Commands::Install => block_on(install(&manager)),
+        Commands::Probe => {
+            let manager = build_manager().await?;
+            block_on(wait_for_services(&manager))?;
+            block_on(probe(&manager))
+        }
+        Commands::Profile(subcommand) => Ok(run_profile_cmd(subcommand)?),
+        Commands::Install => {
+            let manager = build_manager().await?;
+            block_on(wait_for_services(&manager))?;
+            block_on(install(&manager))
+        }
         _ => unimplemented!(),
     }
+}
+
+#[async_std::main]
+async fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+
+    if let Err(error) = run_command(cli).await {
+        eprintln!("{}", error);
+        return Err(error);
+    }
+    Ok(())
 }

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -32,7 +32,7 @@ struct Cli {
 async fn probe(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {
     let another_manager = build_manager().await?;
     let probe = task::spawn(async move { another_manager.probe().await });
-    show_progress(&manager).await?;
+    show_progress(manager).await?;
 
     Ok(probe.await?)
 }
@@ -45,7 +45,7 @@ async fn install(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {
     }
     let another_manager = build_manager().await?;
     let install = task::spawn(async move { another_manager.install().await });
-    show_progress(&manager).await?;
+    show_progress(manager).await?;
 
     Ok(install.await?)
 }

--- a/dinstaller-cli/src/profile.rs
+++ b/dinstaller-cli/src/profile.rs
@@ -1,7 +1,7 @@
 use clap::Subcommand;
 use dinstaller_lib::error::ProfileError;
 use dinstaller_lib::profile::{download, ProfileEvaluator, ProfileValidator, ValidationResult};
-use std::{error::Error, path::Path};
+use std::{path::Path};
 
 #[derive(Subcommand, Debug)]
 pub enum ProfileCommands {

--- a/dinstaller-lib/src/manager.rs
+++ b/dinstaller-lib/src/manager.rs
@@ -35,6 +35,6 @@ impl<'a> ManagerClient<'a> {
     }
 
     pub async fn progress(&self) -> zbus::Result<Progress> {
-        Ok(Progress::from_proxy(&self.progress_proxy).await?)
+        Progress::from_proxy(&self.progress_proxy).await
     }
 }

--- a/dinstaller-lib/src/profile.rs
+++ b/dinstaller-lib/src/profile.rs
@@ -3,7 +3,6 @@ use curl::easy::Easy;
 use jsonschema::JSONSchema;
 use serde_json;
 use std::{
-    error::Error,
     fs, io,
     io::{stdout, Write},
     path::Path,
@@ -108,13 +107,13 @@ impl ProfileEvaluator {
 
         let hwinfo_path = dir.path().join("hw.libsonnet");
         self.write_hwinfo(&hwinfo_path)
-            .map_err(|e| ProfileError::NoHardwareInfo(e))?;
+            .map_err(ProfileError::NoHardwareInfo)?;
 
         let result = Command::new("/usr/bin/jsonnet")
             .arg("profile.jsonnet")
             .current_dir(&dir)
             .output()
-            .map_err(|e| ProfileError::EvaluationError(e))?;
+            .map_err(ProfileError::EvaluationError)?;
         io::stdout().write_all(&result.stdout)?;
         Ok(())
     }
@@ -125,7 +124,7 @@ impl ProfileEvaluator {
     // out of the box.
     fn write_hwinfo(&self, path: &Path) -> Result<(), io::Error> {
         let result = Command::new("/usr/sbin/lshw")
-            .args(&["-json", "-class", "disk"])
+            .args(["-json", "-class", "disk"])
             .output()?;
         let mut file = fs::File::create(path)?;
         file.write(b"{ \"disks\":\n")?;


### PR DESCRIPTION
Follow-up of #32.

## Problem

* There is almost no error handling.
* Exit code is always 0.
* It always try to contact the service, even if it is not needed.

## Solution

This PR introduces better error handling and makes the program to exit with code 1 if something goes wrong. It is neither complete nor perfect, but it is good enough for a first iteration.

## What is missing

- Proper error types for `installation_settings` and other internal modules.
- Better error messages.
- Reduce some duplication in the `run_command` function.