### PR TITLE
fix: use camel case for key names

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -338,6 +338,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "convert_case"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
 name = "cpufeatures"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -432,6 +441,7 @@ version = "0.1.0"
 dependencies = [
  "async-std",
  "clap",
+ "convert_case",
  "dinstaller-lib",
  "indicatif",
  "serde",
@@ -1571,6 +1581,12 @@ checksum = "5c5713f0fc4b5db668a2ac63cdb7bb4469d8c9fed047b1d0292cc7b0ce2ba921"
 dependencies = [
  "tinyvec",
 ]
+
+[[package]]
+name = "unicode-segmentation"
+version = "1.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1dd624098567895118886609431a7c3b8f516e41d30e0643f03d94592a147e36"
 
 [[package]]
 name = "unicode-width"

--- a/README.md
+++ b/README.md
@@ -34,14 +34,14 @@ configuration using JSON (you can use YAML if you like it more):
 
 ```
 $ sudo ./target/debug/dinstaller-cli --format json config show
-{"user":{"full_name":"","user_name":"","password":"","autologin":false},"software":{"product":""}}
+{"user":{"fullName":"","userName":"","password":"","autologin":false},"software":{"product":""}}
 ```
 
 To set one or multiple parameters, just use the `config set` command:
 
 ```
 $ sudo ./target/debug/dinstaller-cli config set software.product=Tumbleweed user.full_name="Jane Doe" \
-    user.user_name="jane.doe" user.password="12345" user.autologin=true
+    user.userName="jane.doe" user.password="12345" user.autologin=true
 ```
 
 The following operation can take some time. Please, make sure to read the *Caveats* section for more
@@ -49,7 +49,7 @@ information.
 
 ```
 $ sudo ./target/debug/dinstaller-cli config show
-{"user":{"full_name":"Jane Doe","user_name":"jane.doe","password":"","autologin":true},"software":{"product":"Tumbleweed"}}
+{"user":{"fullName":"Jane Doe","userName":"jane.doe","password":"","autologin":true},"software":{"product":"Tumbleweed"}}
 ```
 
 If, at some point you want to force a new probing, you can ask D-Installer to repeat the process again:

--- a/dinstaller-cli/Cargo.toml
+++ b/dinstaller-cli/Cargo.toml
@@ -14,3 +14,4 @@ serde_yaml = "0.9.17"
 indicatif= "0.17.3"
 async-std = { version ="1.12.0", features = ["attributes"] }
 thiserror = "1.0.39"
+convert_case = "0.6.0"

--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -1,6 +1,7 @@
 use crate::error::CliError;
 use crate::printers::{print, Format};
 use clap::Subcommand;
+use convert_case::{Case, Casing};
 use dinstaller_lib::connection;
 use dinstaller_lib::install_settings::{InstallSettings, Scope};
 use dinstaller_lib::settings::{SettingObject, SettingValue, Settings};
@@ -41,7 +42,7 @@ pub async fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(
                 .collect();
             let mut model = store.load(Some(scopes)).await?;
             for (key, value) in changes {
-                model.set(&key, SettingValue(value))?;
+                model.set(&key.to_case(Case::Snake), SettingValue(value))?;
             }
             store.store(&model).await
         }
@@ -53,7 +54,7 @@ pub async fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(
         ConfigAction::Add(key, values) => {
             let scope = key_to_scope(&key).unwrap();
             let mut model = store.load(Some(vec![scope])).await?;
-            model.add(&key, SettingObject::from(values))?;
+            model.add(&key.to_case(Case::Snake), SettingObject::from(values))?;
             store.store(&model).await
         }
         ConfigAction::Load(path) => {

--- a/dinstaller-lib/share/examples/profile.json
+++ b/dinstaller-lib/share/examples/profile.json
@@ -1,31 +1,21 @@
 {
-   "localization": {
-      "keyboard": "en_US",
-      "language": "en_US"
-   },
-   "scripts": [
+  "localization": {
+    "keyboard": "en_US",
+    "language": "en_US"
+  },
+  "software": {
+    "product": "ALP"
+  },
+  "storage": {
+    "devices": [
       {
-         "type": "post",
-         "url": "https://myscript.org/test.sh"
-      },
-      {
-         "source": "#!/bin/bash\n\necho hello\n",
-         "type": "pre"
+        "name": "/dev/dm-1"
       }
-   ],
-   "software": {
-      "product": "ALP"
-   },
-   "storage": {
-      "devices": [
-         {
-            "name": "/dev/dm-1"
-         }
-      ]
-   },
-   "user": {
-      "fullName": "Jane Doe",
-      "password": "123456",
-      "userName": "jane.doe"
-   }
+    ]
+  },
+  "user": {
+    "fullName": "Jane Doe",
+    "password": "123456",
+    "userName": "jane.doe"
+  }
 }

--- a/dinstaller-lib/share/examples/profile.jsonnet
+++ b/dinstaller-lib/share/examples/profile.jsonnet
@@ -25,18 +25,4 @@ local findBiggestDisk(disks) =
       },
     ],
   },
-  scripts: [
-    {
-      type: 'post',
-      url: 'https: //myscript.org/test.sh',
-    },
-    {
-      type: 'pre',
-      source: |||
-        #!/bin/bash
-
-        echo hello
-      |||,
-    },
-  ],
 }

--- a/dinstaller-lib/share/profile.schema.json
+++ b/dinstaller-lib/share/profile.schema.json
@@ -72,35 +72,6 @@
           }
         }
       }
-    },
-    "scripts": {
-      "description": "Installation scripts",
-      "type": "array",
-      "items": {
-        "type": "object",
-        "additionalProperties": false,
-        "properties": {
-          "type": {
-            "description": "Script type ('pre' or 'post')",
-            "type": "string",
-            "enum": [
-              "pre",
-              "post"
-            ]
-          },
-          "source": {
-            "description": "Script sources",
-            "type": "string"
-          },
-          "url": {
-            "description": "URL of the script",
-            "type": "string"
-          }
-        }
-      }
     }
-  },
-  "required": [
-    "software"
-  ]
+  }
 }

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -49,6 +49,7 @@ impl FromStr for Scope {
 /// This struct represents installation settings. It serves as an entry point and it is composed of
 /// other structs which hold the settings for each area ("users", "software", etc.).
 #[derive(Debug, Default, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct InstallSettings {
     #[serde(default)]
     pub user: Option<UserSettings>,
@@ -141,6 +142,7 @@ impl Settings for InstallSettings {
 ///
 /// Holds the user settings for the installation.
 #[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct UserSettings {
     /// First user's full name
     pub full_name: Option<String>,
@@ -154,6 +156,7 @@ pub struct UserSettings {
 
 /// Storage settings for installation
 #[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct StorageSettings {
     /// Whether LVM should be enabled
     pub lvm: Option<bool>,
@@ -166,6 +169,7 @@ pub struct StorageSettings {
 
 /// Device to use in the installation
 #[derive(Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct Device {
     /// Device name (e.g., "/dev/sda")
     pub name: String,
@@ -186,6 +190,7 @@ impl TryFrom<SettingObject> for Device {
 
 /// Software settings for installation
 #[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct SoftwareSettings {
     /// ID of the product to install (e.g., "ALP", "Tumbleweed", etc.)
     pub product: Option<String>,


### PR DESCRIPTION
As reported in #36, we are using snake-case for profiles. However, in the JSON world, camel-case is more common. It affects the command line too, although we can use snake and camel-case.