### PR TITLE
fix path to global schema

### DIFF
--- a/dinstaller-lib/src/profile.rs
+++ b/dinstaller-lib/src/profile.rs
@@ -63,7 +63,7 @@ impl ProfileValidator {
         let path = if relative_path.exists() {
             relative_path
         } else {
-            Path::new("/usr/share/dinstaller-rs/profile.schema.json")
+            Path::new("/usr/share/dinstaller-cli/profile.schema.json")
         };
         Self::new(path)
     }


### PR DESCRIPTION
## Problem

Validation failed on the latest ISO with OS error file not found.


## Solution

Adapt to new system location also default path for schema.


## Testing

- *Tested manually*

