### PR TITLE
Do not fall back to the system D-Bus

### DIFF
--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -13,14 +13,9 @@ mod store;
 pub use store::Store;
 
 use crate::error::ServiceError;
-use std::path::Path;
 
 pub async fn connection() -> Result<zbus::Connection, ServiceError> {
-    let path = if Path::new("/run/d-installer/bus").exists() {
-        "/run/d-installer/bus"
-    } else {
-        "/run/dbus/system_bus_socket"
-    };
+    let path = "/run/d-installer/bus";
     let address = format!("unix:path={path}");
     let conn = zbus::ConnectionBuilder::address(address.as_str())?
         .build()


### PR DESCRIPTION
because if our own bus is not available, the user would get a message (service not found on an existing bus) that confuses their debugging efforts

It was a transitional thing anyway.

Before:
> D-Bus service error: org.freedesktop.DBus.Error.ServiceUnknown: The name org.opensuse.DInstaller was not provided by any .service files

After:
> D-Bus service error: I/O error: Connection refused (os error 111)

(which is still awful and I want to fix it later: connection to WHAT)