### PR TITLE
Use JSON as the default format

### DIFF
--- a/dinstaller-cli/src/config.rs
+++ b/dinstaller-cli/src/config.rs
@@ -31,7 +31,7 @@ pub enum ConfigAction {
     Load(String),
 }
 
-pub async fn run(subcommand: ConfigCommands, format: Option<Format>) -> Result<(), Box<dyn Error>> {
+pub async fn run(subcommand: ConfigCommands, format: Format) -> Result<(), Box<dyn Error>> {
     let store = SettingsStore::new(connection().await?).await?;
 
     match parse_config_command(subcommand) {

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -25,8 +25,8 @@ struct Cli {
     pub command: Commands,
 
     /// Format output
-    #[arg(value_enum, short, long)]
-    pub format: Option<Format>,
+    #[arg(value_enum, short, long, default_value_t = Format::Json)]
+    pub format: Format,
 }
 
 async fn probe(manager: &ManagerClient<'_>) -> Result<(), Box<dyn Error>> {

--- a/dinstaller-cli/src/main.rs
+++ b/dinstaller-cli/src/main.rs
@@ -19,7 +19,7 @@ use std::error::Error;
 use std::time::Duration;
 
 #[derive(Parser)]
-#[command(version, about, long_about = None)]
+#[command(name = "dinstaller", version, about, long_about = None)]
 struct Cli {
     #[command(subcommand)]
     pub command: Commands,

--- a/dinstaller-cli/src/printers.rs
+++ b/dinstaller-cli/src/printers.rs
@@ -16,18 +16,14 @@ use std::io::Write;
 /// print(user, io::stdout(), Some(Format::Json))
 ///   .expect("Something went wrong!")
 /// ```
-pub fn print<T, W>(
-    content: T,
-    writer: W,
-    format: Option<Format>,
-) -> Result<(), Box<dyn error::Error>>
+pub fn print<T, W>(content: T, writer: W, format: Format) -> Result<(), Box<dyn error::Error>>
 where
     T: serde::Serialize + Debug,
     W: Write,
 {
     let printer: Box<dyn Printer<T, W>> = match format {
-        Some(Format::Json) => Box::new(JsonPrinter { content, writer }),
-        Some(Format::Yaml) => Box::new(YamlPrinter { content, writer }),
+        Format::Json => Box::new(JsonPrinter { content, writer }),
+        Format::Yaml => Box::new(YamlPrinter { content, writer }),
         _ => Box::new(TextPrinter { content, writer }),
     };
     printer.print()


### PR DESCRIPTION
* Use JSON as the default format.
* Fix the command name in the help text.