### PR TITLE
Allow setting root password and/or SSH public key

### DIFF
--- a/dinstaller-lib/share/examples/profile.json
+++ b/dinstaller-lib/share/examples/profile.json
@@ -17,5 +17,9 @@
     "fullName": "Jane Doe",
     "password": "123456",
     "userName": "jane.doe"
+  },
+  "root": {
+    "password": "nots3cr3t",
+    "sshKey": "..."
   }
 }

--- a/dinstaller-lib/share/examples/profile.jsonnet
+++ b/dinstaller-lib/share/examples/profile.jsonnet
@@ -13,6 +13,10 @@ local findBiggestDisk(disks) =
     userName: 'jane.doe',
     password: '123456',
   },
+  root: {
+    password: 'nots3cr3t',
+    sshKey: '...',
+  },
   // look ma, there are comments!
   localization: {
     language: 'en_US',

--- a/dinstaller-lib/share/profile.schema.json
+++ b/dinstaller-lib/share/profile.schema.json
@@ -39,6 +39,20 @@
         "password"
       ]
     },
+    "root": {
+      "description": "Root authentication settings",
+      "type": "object",
+      "properties": {
+        "password": {
+          "description": "Root user password",
+          "type": "string"
+        },
+        "sshPublicKey": {
+          "description": "Root SSH public key",
+          "type": "string"
+        }
+      }
+    },
     "localization": {
       "description": "Localization settings",
       "type": "object",

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -109,12 +109,12 @@ impl Settings for InstallSettings {
                 "user" => {
                     let user = self.user.get_or_insert(Default::default());
                     // User settings are flatten. Pass the full attribute name.
-                    user.set(&attr, value)?
+                    user.set(attr, value)?
                 }
                 "root" => {
                     let root = self.user.get_or_insert(Default::default());
                     // Root settings are flatten. Pass the full attribute name.
-                    root.set(&attr, value)?
+                    root.set(attr, value)?
                 }
                 "storage" => {
                     let storage = self.storage.get_or_insert(Default::default());

--- a/dinstaller-lib/src/install_settings.rs
+++ b/dinstaller-lib/src/install_settings.rs
@@ -111,6 +111,11 @@ impl Settings for InstallSettings {
                     // User settings are flatten. Pass the full attribute name.
                     user.set(&attr, value)?
                 }
+                "root" => {
+                    let root = self.user.get_or_insert(Default::default());
+                    // Root settings are flatten. Pass the full attribute name.
+                    root.set(&attr, value)?
+                }
                 "storage" => {
                     let storage = self.storage.get_or_insert(Default::default());
                     storage.set(id, value)?
@@ -147,6 +152,7 @@ impl Settings for InstallSettings {
 pub struct UserSettings {
     #[serde(rename = "user")]
     pub first_user: Option<FirstUserSettings>,
+    pub root: Option<RootUserSettings>,
 }
 
 impl Settings for UserSettings {
@@ -156,6 +162,10 @@ impl Settings for UserSettings {
                 "user" => {
                     let first_user = self.first_user.get_or_insert(Default::default());
                     first_user.set(id, value)?
+                }
+                "root" => {
+                    let root_user = self.root.get_or_insert(Default::default());
+                    root_user.set(id, value)?
                 }
                 _ => return Err("unknown attribute"),
             }
@@ -185,6 +195,19 @@ pub struct FirstUserSettings {
     pub password: Option<String>,
     /// Whether auto-login should enabled or not
     pub autologin: Option<bool>,
+}
+
+/// Root user settings
+///
+/// Holds the settings for the root user.
+#[derive(Debug, Default, Settings, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct RootUserSettings {
+    /// Root's password (in clear text)
+    #[serde(skip_serializing)]
+    pub password: Option<String>,
+    /// Root SSH public key
+    pub ssh_public_key: Option<String>,
 }
 
 /// Storage settings for installation

--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -38,11 +38,11 @@ impl<'a> UsersStore<'a> {
     pub async fn store(&self, settings: &UserSettings) -> Result<(), Box<dyn Error>> {
         // fixme: improve
         if let Some(settings) = &settings.first_user {
-            self.store_first_user(&settings).await?;
+            self.store_first_user(settings).await?;
         }
 
         if let Some(settings) = &settings.root {
-            self.store_root_user(&settings).await?;
+            self.store_root_user(settings).await?;
         }
         Ok(())
     }

--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -1,4 +1,4 @@
-use crate::install_settings::{FirstUserSettings, UserSettings};
+use crate::install_settings::{FirstUserSettings, RootUserSettings, UserSettings};
 use crate::users::{FirstUser, UsersClient};
 use std::error::Error;
 use zbus::Connection;
@@ -23,23 +23,53 @@ impl<'a> UsersStore<'a> {
             full_name: Some(first_user.full_name),
             password: Some(first_user.password),
         };
+        let ssh_public_key = self.users_client.root_ssh_key().await;
+        let root_user = RootUserSettings {
+            // todo: expose the password
+            password: None,
+            ssh_public_key: ssh_public_key.ok(),
+        };
         Ok(UserSettings {
             first_user: Some(first_user),
+            root: Some(root_user),
         })
     }
 
     pub async fn store(&self, settings: &UserSettings) -> Result<(), Box<dyn Error>> {
         // fixme: improve
         if let Some(settings) = &settings.first_user {
-            let first_user = FirstUser {
-                user_name: settings.user_name.clone().unwrap_or_default(),
-                full_name: settings.full_name.clone().unwrap_or_default(),
-                autologin: settings.autologin.unwrap_or_default(),
-                password: settings.password.clone().unwrap_or_default(),
-                ..Default::default()
-            };
-            self.users_client.set_first_user(&first_user).await?;
+            self.store_first_user(&settings).await?;
         }
+
+        if let Some(settings) = &settings.root {
+            self.store_root_user(&settings).await?;
+        }
+        Ok(())
+    }
+
+    async fn store_first_user(&self, settings: &FirstUserSettings) -> Result<(), Box<dyn Error>> {
+        let first_user = FirstUser {
+            user_name: settings.user_name.clone().unwrap_or_default(),
+            full_name: settings.full_name.clone().unwrap_or_default(),
+            autologin: settings.autologin.unwrap_or_default(),
+            password: settings.password.clone().unwrap_or_default(),
+            ..Default::default()
+        };
+        self.users_client.set_first_user(&first_user).await?;
+        Ok(())
+    }
+
+    async fn store_root_user(&self, settings: &RootUserSettings) -> Result<(), Box<dyn Error>> {
+        if let Some(root_password) = &settings.password {
+            self.users_client
+                .set_root_password(root_password, false)
+                .await?;
+        }
+
+        if let Some(ssh_public_key) = &settings.ssh_public_key {
+            self.users_client.set_root_sshkey(ssh_public_key).await?;
+        }
+
         Ok(())
     }
 }

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -2,7 +2,6 @@
 
 use super::proxies::Users1Proxy;
 use crate::error::ServiceError;
-use crate::install_settings::UserSettings;
 use crate::settings::{SettingValue, Settings};
 use serde::Serialize;
 use zbus::Connection;
@@ -40,16 +39,6 @@ impl FirstUser {
             autologin: data.3,
             data: data.4,
         })
-    }
-
-    pub fn from_user_settings(settings: &UserSettings) -> Self {
-        FirstUser {
-            user_name: settings.user_name.clone().unwrap_or_default(),
-            full_name: settings.full_name.clone().unwrap_or_default(),
-            autologin: settings.autologin.unwrap_or_default(),
-            password: settings.password.clone().unwrap_or_default(),
-            ..Default::default()
-        }
     }
 }
 

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -80,7 +80,7 @@ impl<'a> UsersClient<'a> {
     ) -> Result<u32, ServiceError> {
         Ok(self
             .users_proxy
-            .set_root_password(&value, encrypted)
+            .set_root_password(value, encrypted)
             .await?)
     }
 

--- a/dinstaller-lib/src/users.rs
+++ b/dinstaller-lib/src/users.rs
@@ -72,6 +72,18 @@ impl<'a> UsersClient<'a> {
         FirstUser::from_dbus(self.users_proxy.first_user().await)
     }
 
+    /// SetRootPassword method
+    pub async fn set_root_password(
+        &self,
+        value: &str,
+        encrypted: bool,
+    ) -> Result<u32, ServiceError> {
+        Ok(self
+            .users_proxy
+            .set_root_password(&value, encrypted)
+            .await?)
+    }
+
     /// Whether the root password is set or not
     pub async fn is_root_password(&self) -> Result<bool, ServiceError> {
         Ok(self.users_proxy.root_password_set().await?)
@@ -80,6 +92,11 @@ impl<'a> UsersClient<'a> {
     /// Returns the SSH key for the root user
     pub async fn root_ssh_key(&self) -> zbus::Result<String> {
         self.users_proxy.root_sshkey().await
+    }
+
+    /// SetRootSSHKey method
+    pub async fn set_root_sshkey(&self, value: &str) -> Result<u32, ServiceError> {
+        Ok(self.users_proxy.set_root_sshkey(value).await?)
     }
 
     /// Set the configuration for the first user

--- a/package/d-installer-cli.changes
+++ b/package/d-installer-cli.changes
@@ -1,4 +1,25 @@
 -------------------------------------------------------------------
+Wed Mar 22 09:39:29 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Add support for setting root authentication mechanisms
+  (gh#yast/d-installer-cli#47).
+
+-------------------------------------------------------------------
+Tue Mar 21 16:06:02 UTC 2023 - Martin Vidner <mvidner@suse.com>
+
+- Do not fall back to the system D-Bus (gh#yast/d-installer-cli#45).
+
+-------------------------------------------------------------------
+Wed Mar 21 13:28:01 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
+
+- Use JSON as the default format (gh#yast/d-installer-cli#46).
+
+-------------------------------------------------------------------
+Tue Mar 21 08:55:39 UTC 2023 - Josef Reidinger <jreidinger@suse.com>
+
+- Fix the path of the JSON schema (gh#yast/d-installer-cli#44).
+
+-------------------------------------------------------------------
 Thu Mar 16 11:56:42 UTC 2023 - Imobach Gonzalez Sosa <igonzalezsosa@suse.com>
 
 - First version of the package:


### PR DESCRIPTION
* Allow setting root password or SSH public key.
* Do not nest the root settings below the `user` section. Let's keep the schema as flat as possible.
* Update the changes file.
* After March's prototype we can extend the macros to reduce the boilerplate.
* TODO: allow reading the public key from a file.