### PR TITLE
Better error message when our bus cannot be found.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -463,6 +463,7 @@ dependencies = [
 name = "dinstaller-lib"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "async-std",
  "curl",
  "dinstaller-derive",

--- a/dinstaller-lib/Cargo.toml
+++ b/dinstaller-lib/Cargo.toml
@@ -16,3 +16,4 @@ features = { version = "0.10.0", default-features = false }
 serde_json = "1.0.94"
 tempfile = "3.4.0"
 thiserror = "1.0.39"
+anyhow = "1.0"

--- a/dinstaller-lib/src/error.rs
+++ b/dinstaller-lib/src/error.rs
@@ -5,8 +5,12 @@ use thiserror::Error;
 use zbus;
 
 #[derive(Error, Debug)]
-#[error("D-Bus service error: {0}")]
-pub struct ServiceError(#[from] zbus::Error);
+pub enum ServiceError {
+    #[error("D-Bus service error: {0}")]
+    DBus(#[from] zbus::Error),
+    #[error("Input/output error: {0}")]
+    InputOutputError(#[from] io::Error),
+}
 
 #[derive(Error, Debug)]
 pub enum ProfileError {

--- a/dinstaller-lib/src/error.rs
+++ b/dinstaller-lib/src/error.rs
@@ -8,8 +8,10 @@ use zbus;
 pub enum ServiceError {
     #[error("D-Bus service error: {0}")]
     DBus(#[from] zbus::Error),
-    #[error("Input/output error: {0}")]
-    InputOutputError(#[from] io::Error),
+    // it's fine to say only "Error" because the original
+    // specific error will be printed too
+    #[error("Error: {0}")]
+    Anyhow(#[from] anyhow::Error),
 }
 
 #[derive(Error, Debug)]

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -21,7 +21,7 @@ pub async fn connection() -> Result<zbus::Connection, ServiceError> {
     let path = "/run/d-installer/bus";
     if !Path::new(path).exists() {
         let io_err = Error::new(ErrorKind::NotFound, format!("Bus socket {} does not exist", path));
-        return Err(ServiceError::InputOutputError(io_err));
+        return Err(io_err.into());
     }
 
     let address = format!("unix:path={path}");

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -15,15 +15,13 @@ pub use store::Store;
 use crate::error::ServiceError;
 use std::path::Path;
 use std::io::{Error, ErrorKind};
-use std::sync::Arc;
 
 
 pub async fn connection() -> Result<zbus::Connection, ServiceError> {
     let path = "/run/d-installer/bus";
     if !Path::new(path).exists() {
         let io_err = Error::new(ErrorKind::NotFound, format!("Bus socket {} does not exist", path));
-        let zbus_err = zbus::Error::InputOutput(Arc::new(io_err));
-        return Err(ServiceError::from(zbus_err));
+        return Err(ServiceError::InputOutputError(io_err));
     }
 
     let address = format!("unix:path={path}");

--- a/dinstaller-lib/src/lib.rs
+++ b/dinstaller-lib/src/lib.rs
@@ -13,9 +13,19 @@ mod store;
 pub use store::Store;
 
 use crate::error::ServiceError;
+use std::path::Path;
+use std::io::{Error, ErrorKind};
+use std::sync::Arc;
+
 
 pub async fn connection() -> Result<zbus::Connection, ServiceError> {
     let path = "/run/d-installer/bus";
+    if !Path::new(path).exists() {
+        let io_err = Error::new(ErrorKind::NotFound, format!("Bus socket {} does not exist", path));
+        let zbus_err = zbus::Error::InputOutput(Arc::new(io_err));
+        return Err(ServiceError::from(zbus_err));
+    }
+
     let address = format!("unix:path={path}");
     let conn = zbus::ConnectionBuilder::address(address.as_str())?
         .build()


### PR DESCRIPTION
## Problem

When this CLI fails to connect to the d-installer bus, the error message omits important information: which file (socket) is missing.

```sh
systemctl stop d-installer.service
./dinstaller config show
```

Before:
> D-Bus service error: I/O error: No such file or directory (os error 2)
> Error: ServiceError(InputOutput(Os { code: 2, kind: NotFound, message: "No such file or directory" }))


## Solution

Explicitly test for the socket existence and return a custom error saying it is missing.

~~After, try 1~~
> ~~D-Bus service error: I/O error: Bus socket /run/d-installer/bus does not exist~~
> ~~Error: ServiceError(InputOutput(Custom { kind: NotFound, error: "Bus socket /run/d-installer/bus does not exist" }))~~


~~After, try2~~
> ~~Input/output error: Bus socket /run/d-installer/bus does not exist~~
> ~~Error: InputOutputError(Custom { kind: NotFound, error: "Bus socket /run/d-installer/bus does not exist" })~~

~~I am sure this is very clumsy.~~

~~In general I feel disappointed that Rust does not seem to have an easy way to include important context (filenames) in the standard errors it uses.~~

After, with *anyhow*

```console
$ dinstaller config show`
Error: Connecting to D-Bus address unix:path=/run/d-installer/bus
Error: Anyhow(Connecting to D-Bus address unix:path=/run/d-installer/bus

Caused by:
    0: I/O error: No such file or directory (os error 2)
    1: No such file or directory (os error 2))
```

## Testing

Tested manually

## Screenshots

See text above