### PR TITLE
add better user erorr reporting

### DIFF
--- a/dinstaller-lib/src/error.rs
+++ b/dinstaller-lib/src/error.rs
@@ -21,3 +21,11 @@ pub enum ProfileError {
     #[error("The profile is not a valid JSON file")]
     FormatError(#[from] serde_json::Error),
 }
+
+#[derive(Error, Debug)]
+pub enum WrongParameter {
+    #[error("Unknown product '{0}'. Available products: '{1:?}'")]
+    UnknownProduct(String, Vec<String>),
+    #[error("Wrong user parameters: '{0:?}'")]
+    WrongUser(Vec<String>)
+}

--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -58,7 +58,6 @@ impl<'a> UsersStore<'a> {
         };
         let (result, issues) = self.users_client.set_first_user(&first_user).await?;
         if !result {
-            eprintln!("wrong user found");
             return Err(Box::new(WrongParameter::WrongUser(issues)));  
         }
         Ok(())

--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -1,5 +1,6 @@
 use crate::install_settings::{FirstUserSettings, RootUserSettings, UserSettings};
 use crate::users::{FirstUser, UsersClient};
+use crate::error::WrongParameter;
 use std::error::Error;
 use zbus::Connection;
 
@@ -55,7 +56,11 @@ impl<'a> UsersStore<'a> {
             password: settings.password.clone().unwrap_or_default(),
             ..Default::default()
         };
-        self.users_client.set_first_user(&first_user).await?;
+        let (result, issues) = self.users_client.set_first_user(&first_user).await?;
+        if !result {
+            eprintln!("wrong user found");
+            return Err(Box::new(WrongParameter::WrongUser(issues)));  
+        }
         Ok(())
     }
 


### PR DESCRIPTION
## Problem

Improve wrong parameters passed by user or profile.


## Testing

- *Tested manually*


## Screenshots

```sh
1248996:/ # dinstaller config set user.userName="test"
Wrong user parameters: '["No password entered.\nTry again."]'
Error: WrongUser(["No password entered.\nTry again."])
f967f1248996:/ # dinstaller config set user.userName="*"
Wrong user parameters: '["The username must be between 2 and 32 characters in length.\nTry again.", "The username may contain only\nLatin letters and digits, \"-\", \".\", and \"_\"\nand must begin with a letter or \"_\".\nTry again.", "No password entered.\nTry again."]'
Error: WrongUser(["The username must be between 2 and 32 characters in length.\nTry again.", "The username may contain only\nLatin letters and digits, \"-\", \".\", and \"_\"\nand must begin with a letter or \"_\".\nTry again.", "No password entered.\nTry again."])
f967f1248996:/ # dinstaller config set user.userName="test" user.password=test

```

## Remaining Issues

- [ ] check product
- [ ] debug why invalid value in profile cause dbus crash
- [ ] Fix on dinstaller side that "\nTry again."



dbus crash:
```
f967f1248996:/ # cat /checkout/profile.json 
{
  "user": {
    "fullName": "Jane Doe",
    "password": "123456",
    "userName": "*"
  }
}
f967f1248996:/ # dinstaller config load /checkout/profile.json 
org.freedesktop.DBus.Error.Failed: no implicit conversion of nil into Array; caused by 1 sender=:1.21 -> dest=org.opensuse.DInstaller.Users serial=6 reply_serial= path=/org/opensuse/DInstaller/Users1; interface=org.opensuse.DInstaller.Users1; member=SetFirstUser error_name=
Error: MethodError(OwnedErrorName(ErrorName(Str(Owned("org.freedesktop.DBus.Error.Failed")))), Some("no implicit conversion of nil into Array; caused by 1 sender=:1.21 -> dest=org.opensuse.DInstaller.Users serial=6 reply_serial= path=/org/opensuse/DInstaller/Users1; interface=org.opensuse.DInstaller.Users1; member=SetFirstUser error_name="), Msg { type: Error, sender: UniqueName(Str(Borrowed(":1.6"))), reply-serial: 6, body: Signature("sas") })
```
