### PR TITLE
Add validation also to software product

### DIFF
--- a/dinstaller-lib/src/store/users.rs
+++ b/dinstaller-lib/src/store/users.rs
@@ -56,8 +56,8 @@ impl<'a> UsersStore<'a> {
             password: settings.password.clone().unwrap_or_default(),
             ..Default::default()
         };
-        let (result, issues) = self.users_client.set_first_user(&first_user).await?;
-        if !result {
+        let (success, issues) = self.users_client.set_first_user(&first_user).await?;
+        if !success {
             return Err(Box::new(WrongParameter::WrongUser(issues)));  
         }
         Ok(())


### PR DESCRIPTION
## Problem

wrong product error is too cryptic


## Solution

Improve it.


## Testing

- *Tested manually*


## Screenshots
old output:

```
dinstaller config set software.product=test
D-Bus service error: org.freedesktop.DBus.Error.Failed: ArgumentError; caused by 1 sender=:1.10 -> dest=org.opensuse.DInstaller.Software serial=6 reply_serial= path=/org/opensuse/DInstaller/Software1; interface=org.opensuse.DInstaller.Software1; member=SelectProduct error_name=
Error: DBus(MethodError(OwnedErrorName(ErrorName(Str(Owned("org.freedesktop.DBus.Error.Failed")))), Some("ArgumentError; caused by 1 sender=:1.10 -> dest=org.opensuse.DInstaller.Software serial=6 reply_serial= path=/org/opensuse/DInstaller/Software1; interface=org.opensuse.DInstaller.Software1; member=SelectProduct error_name="), Msg { type: Error, sender: UniqueName(Str(Borrowed(":1.3"))), reply-serial: 6, body: Signature("sas") }))
```

new output:
```
6df29e52e2c1:/ # dinstaller config set software.product=test
Unknown product 'test'. Available products: '["ALP-Bedrock", "ALP-Micro", "Tumbleweed", "Leap16"]'
Error: UnknownProduct("test", ["ALP-Bedrock", "ALP-Micro", "Tumbleweed", "Leap16"])

6df29e52e2c1:/ # cat /checkout/profile.json 
{
  "software": {
    "product": "Test"
  },
  "user": {
    "fullName": "Jane Doe",
    "password": "123456",
    "userName": "wrong one toooooo long soooo long reaaaaaly long"
  }
}
6df29e52e2c1:/ # dinstaller config load /checkout/profile.json 
Unknown product 'Test'. Available products: '["ALP-Bedrock", "ALP-Micro", "Tumbleweed", "Leap16"]'
Error: UnknownProduct("Test", ["ALP-Bedrock", "ALP-Micro", "Tumbleweed", "Leap16"])

6df29e52e2c1:/ # cat /checkout/profile.json 
{
  "user": {
    "fullName": "Jane Doe",
    "password": "123456",
    "userName": "wrong one toooooo long soooo long reaaaaaly long"
  }
}
6df29e52e2c1:/ # dinstaller config load /checkout/profile.json 
Wrong user parameters: '["The username must be between 2 and 32 characters in length.\nTry again.", "The username may contain only\nLatin letters and digits, \"-\", \".\", and \"_\"\nand must begin with a letter or \"_\".\nTry again."]'
Error: WrongUser(["The username must be between 2 and 32 characters in length.\nTry again.", "The username may contain only\nLatin letters and digits, \"-\", \".\", and \"_\"\nand must begin with a letter or \"_\".\nTry again."])
```

